### PR TITLE
initialize puppet settings

### DIFF
--- a/lib/puppet-cleaner/inspect.rb
+++ b/lib/puppet-cleaner/inspect.rb
@@ -2,7 +2,9 @@ require 'puppet'
 
 module Puppet::Cleaner
   def self.inspect(filename)
-    Puppet[:manifest] = filename
+    Puppet.initialize_settings
+
+    Puppet.settings[:manifest] = filename
     tc = Puppet::Node::Environment.new(Puppet[:environment]).known_resource_types
     catalog = [:nodes, :hostclasses, :definitions].collect {|meth| tc.send(meth) }
     tc.clear


### PR DESCRIPTION
Puppet now requires settings to be initialized after loading the library.
